### PR TITLE
Finalized grpc-client-implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*/go.sum
+*/server

--- a/images-portal-grpc-client/go.mod
+++ b/images-portal-grpc-client/go.mod
@@ -1,0 +1,24 @@
+module server
+
+go 1.13
+
+// 18/03/20 there is a versioning problem between k8s.io/client-go and googleapis/gnostic
+// one fix is using specific versions which do not collide
+
+require (
+	github.com/Microsoft/go-winio v0.4.14 // indirect
+	github.com/aws/aws-sdk-go v1.29.26 // indirect
+	github.com/bsuro10/images_portal v0.0.0-20190812093923-e702f4cdb78b
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/docker v1.13.1 // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
+	github.com/googleapis/gnostic v0.4.0
+	github.com/imdario/mergo v0.3.8 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	google.golang.org/grpc v1.28.0
+	k8s.io/api v0.17.4 // indirect
+	k8s.io/client-go v0.17.0
+	k8s.io/utils v0.0.0-20200318093247-d1ab8797c558 // indirect
+)

--- a/images-portal-grpc-client/server.go
+++ b/images-portal-grpc-client/server.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
-	oc "github.com/bsuro10/images-portal/images-portal-grpc-client/interfaces/openshift_client"
-	"github.com/bsuro10/images-portal/images-portal-grpc-server/api/docker"
+	oc "github.com/bsuro10/images_portal/images-portal-grpc-client/interfaces/openshift_client"
+	"github.com/bsuro10/images_portal/images-portal-grpc-server/api/docker"
 	"google.golang.org/grpc"
 )
 

--- a/images-portal-grpc-server/Dockerfile
+++ b/images-portal-grpc-server/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:latest as builder
-WORKDIR $GOPATH/src/github.com/bsuro10/images-portal/images-portal-grpc-server
+WORKDIR $GOPATH/src/github.com/bsuro10/images_portal/images-portal-grpc-server
 COPY . .
 RUN go get -d -v ./...
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /build/server ./server

--- a/images-portal-grpc-server/server/main.go
+++ b/images-portal-grpc-server/server/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/bsuro10/images-portal/images-portal-grpc-server/api/docker"
+	"github.com/bsuro10/images_portal/images-portal-grpc-server/api/docker"
 	"github.com/docker/docker/client"
 	"google.golang.org/grpc"
 )


### PR DESCRIPTION
1. Corrected path to images_portal repo on grpc-client
2. gitignore, go.mod for specific versions of client-go and gnostic (current latest versions are incompatible)